### PR TITLE
feat: allow configuration of required indicator opacity

### DIFF
--- a/packages/vaadin-lumo-styles/mixins/required-field.js
+++ b/packages/vaadin-lumo-styles/mixins/required-field.js
@@ -43,7 +43,7 @@ const requiredField = css`
   [part='required-indicator']::after {
     content: var(--lumo-required-field-indicator, '•');
     transition: opacity 0.2s;
-    opacity: 0;
+    opacity: var(--lumo-required-field-indicator-opacity, 0);
     color: var(--lumo-required-field-indicator-color, var(--lumo-primary-text-color));
     position: absolute;
     right: 0;
@@ -52,7 +52,7 @@ const requiredField = css`
   }
 
   :host([required]:not([has-value])) [part='required-indicator']::after {
-    opacity: 1;
+    opacity: var(--lumo-required-field-indicator-opacity, 1);
   }
 
   :host([invalid]) [part='required-indicator']::after {


### PR DESCRIPTION
## Description

Allow easy customizing of required indicator's opacity 

Related to https://github.com/vaadin/web-components/issues/85#issuecomment-846949741

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
